### PR TITLE
Use non-blocking `Async.Global.ofJob` rather than blocking `run`.

### DIFF
--- a/src/Hopac.Extras/ObjectPool.fs
+++ b/src/Hopac.Extras/ObjectPool.fs
@@ -4,6 +4,7 @@ open Hopac
 open Hopac.Infixes
 open Hopac.Job.Infixes
 open Hopac.Alt.Infixes
+open Hopac.Extensions
 open System
 
 type private PoolEntry<'a> = 
@@ -103,7 +104,7 @@ type ObjectPool with
     /// Applies a function on an instance from pool. Returns the function result.
     member x.WithInstance f = x.WithInstanceJob (fun a -> Job.result (f a))
     /// Returns an Async that applies a function on an instance from pool and returns the function result.
-    member x.WithInstanceAsync f = async { return run (x.WithInstance f) }
+    member x.WithInstanceAsync f = x.WithInstance f |> Async.Global.ofJob
     /// Applies a function on an instance from pool, synchronously, in the thread in which it's called.
     /// Warning! Can deadlock being called from application main thread.
     member x.WithInstanceSync f = x.WithInstance f |> run

--- a/src/Hopac.Extras/ParallelExecutor.fs
+++ b/src/Hopac.Extras/ParallelExecutor.fs
@@ -55,4 +55,4 @@ type ParallelExecutor<'msg, 'error>
             setDegreeAlt() <|>? workDoneAlt()
     do start pool
     /// Sets new degree of parallelism.
-    member __.SetDegree value = setDegree <-+ value |> run
+    member __.SetDegree value = setDegree <-+ value |> start


### PR DESCRIPTION
I noticed the use of blocking `run` in `ObjectPool` to convert a job to an async.  It can be replaced with a non-blocking version using `Async.Global.ofJob`.  `run` uses blocking to wait for a job to finish, but it is also possible to use non-blocking wait when converting between jobs and asyncs, which is what the conversion functions provided by Hopac do.

The second commit simply replaces a use of `run` with `start`.  As the operation being executed is an asynchronous send, it makes no semantic difference, but `start` is slightly faster.